### PR TITLE
Improve auth controllers and persistence

### DIFF
--- a/lib/constants/hive_constant.dart
+++ b/lib/constants/hive_constant.dart
@@ -5,4 +5,6 @@ class HiveConstant {
   static const String authBox = "auth-box";
   static const String listCrudDataModel = "list-crud-model";
   static const String bearerToken = "bearer-token";
+  static const String rememberMe = "remember-me";
+  static const String rememberedEmail = "remembered-email";
 }

--- a/lib/features/auth/controllers/auth_controller.dart
+++ b/lib/features/auth/controllers/auth_controller.dart
@@ -1,13 +1,15 @@
+import 'dart:async';
+
 import 'package:get/get.dart';
 import 'package:budgetin/utils/services/supabase_service.dart';
 import 'package:budgetin/utils/functions/error_parser.dart';
-import 'package:budgetin/shared/styles/styles.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AuthController extends GetxController {
   static AuthController get to => Get.find();
 
   final SupabaseService _supabaseService = Get.find<SupabaseService>();
+  StreamSubscription<AuthState>? _authStateSubscription;
 
   // Observable variables
   final Rx<User?> _currentUser = Rx<User?>(null);
@@ -28,9 +30,16 @@ class AuthController extends GetxController {
   }
 
   void _initAuthListener() {
-    _supabaseService.authStateChanges.listen((AuthState state) {
+    _authStateSubscription =
+        _supabaseService.authStateChanges.listen((AuthState state) {
       _currentUser.value = state.session?.user;
     });
+  }
+
+  @override
+  void onClose() {
+    _authStateSubscription?.cancel();
+    super.onClose();
   }
 
   void _getCurrentUser() {
@@ -52,18 +61,7 @@ class AuthController extends GetxController {
         data: fullName != null ? {'full_name': fullName} : null,
       );
 
-      if (response.user != null) {
-        // Show success message for sign up to inform user to check email
-        Get.snackbar(
-          'Berhasil',
-          'Akun berhasil dibuat! Silakan cek email Anda untuk verifikasi.',
-          snackPosition: SnackPosition.TOP,
-          backgroundColor: AppColors.success,
-          colorText: AppColors.white,
-        );
-        return true;
-      }
-      return false;
+      return response.user != null;
     } catch (e) {
       final userFriendlyMessage = ErrorParser.parseAuthError(e);
       _errorMessage.value = userFriendlyMessage;
@@ -109,11 +107,12 @@ class AuthController extends GetxController {
 
       final success = await _supabaseService.signInWithGoogle();
 
-      if (success) {
-        // Success message will be handled by UI if needed
-        return true;
+      if (!success) {
+        _errorMessage.value =
+            'Unable to sign in with Google. Please try again.';
       }
-      return false;
+
+      return success;
     } catch (e) {
       final userFriendlyMessage = ErrorParser.parseAuthError(e);
       _errorMessage.value = userFriendlyMessage;

--- a/lib/features/auth/sub_features/sign_in/controllers/sign_in_controller.dart
+++ b/lib/features/auth/sub_features/sign_in/controllers/sign_in_controller.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:budgetin/constants/hive_constant.dart';
 import 'package:budgetin/features/auth/controllers/auth_controller.dart';
+import 'package:budgetin/utils/services/hive_service.dart';
 import 'package:budgetin/configs/routes/route.dart';
 
 class SignInController extends GetxController {
   static SignInController get to => Get.find();
 
   late AuthController _authController;
+  late HiveService _hiveService;
 
   // Form controllers
   late TextEditingController emailController;
@@ -33,9 +36,37 @@ class SignInController extends GetxController {
 
   void _initControllers() {
     _authController = Get.find<AuthController>();
+    _hiveService = Get.find<HiveService>();
     emailController = TextEditingController();
     passwordController = TextEditingController();
     formKey = GlobalKey<FormState>();
+    _loadRememberedCredentials();
+  }
+
+  void _loadRememberedCredentials() {
+    final savedRememberMe =
+        _hiveService.get<bool>(key: HiveConstant.rememberMe) ?? false;
+    _rememberMe.value = savedRememberMe;
+
+    if (savedRememberMe) {
+      final savedEmail =
+          _hiveService.get<String>(key: HiveConstant.rememberedEmail) ?? '';
+      emailController.text = savedEmail;
+    }
+  }
+
+  void _persistRememberMe(bool value) {
+    _hiveService.set<bool>(key: HiveConstant.rememberMe, data: value);
+    if (!value) {
+      _hiveService.remove(key: HiveConstant.rememberedEmail);
+    }
+  }
+
+  @override
+  void onClose() {
+    emailController.dispose();
+    passwordController.dispose();
+    super.onClose();
   }
 
   void clearError() {
@@ -47,16 +78,27 @@ class SignInController extends GetxController {
   }
 
   void toggleRememberMe(bool? value) {
-    _rememberMe.value = value ?? false;
+    final newValue = value ?? false;
+    _rememberMe.value = newValue;
+    _persistRememberMe(newValue);
   }
 
   Future<void> signIn() async {
     if (!formKey.currentState!.validate()) return;
 
-    await _authController.signIn(
+    final success = await _authController.signIn(
       email: emailController.text.trim(),
       password: passwordController.text,
     );
+
+    if (success && rememberMe) {
+      _hiveService.set<String>(
+        key: HiveConstant.rememberedEmail,
+        data: emailController.text.trim(),
+      );
+    } else if (!rememberMe) {
+      _hiveService.remove(key: HiveConstant.rememberedEmail);
+    }
 
     // AuthStateService akan handle redirect, jadi tidak perlu manual redirect
     // Error message sudah ditampilkan melalui UI error display

--- a/lib/features/auth/sub_features/sign_up/controllers/sign_up_controller.dart
+++ b/lib/features/auth/sub_features/sign_up/controllers/sign_up_controller.dart
@@ -65,6 +65,15 @@ class SignUpController extends GetxController {
     formKey = GlobalKey<FormState>();
   }
 
+  @override
+  void onClose() {
+    _fullNameController?.dispose();
+    _emailController?.dispose();
+    _passwordController?.dispose();
+    _confirmPasswordController?.dispose();
+    super.onClose();
+  }
+
   void clearError() {
     _authController.clearError();
   }
@@ -75,6 +84,13 @@ class SignUpController extends GetxController {
 
   void toggleConfirmPasswordVisibility() {
     _isConfirmPasswordVisible.value = !_isConfirmPasswordVisible.value;
+  }
+
+  void toggleAcceptTerms(bool? value) {
+    _acceptTerms.value = value ?? false;
+    if (_acceptTerms.value) {
+      _authController.clearError();
+    }
   }
 
   String? validateFullName(String? value) {
@@ -119,6 +135,13 @@ class SignUpController extends GetxController {
 
   Future<void> signUp() async {
     if (!formKey.currentState!.validate()) return;
+
+    if (!acceptTerms) {
+      _authController.setErrorMessage(
+        'Please accept the terms & conditions to continue.',
+      );
+      return;
+    }
 
     final success = await _authController.signUp(
       email: emailController.text.trim(),

--- a/lib/features/auth/sub_features/sign_up/controllers/sign_up_controller.dart
+++ b/lib/features/auth/sub_features/sign_up/controllers/sign_up_controller.dart
@@ -9,31 +9,20 @@ class SignUpController extends GetxController {
   late AuthController _authController;
 
   // Form controllers
-  TextEditingController? _fullNameController;
-  TextEditingController? _emailController;
-  TextEditingController? _passwordController;
-  TextEditingController? _confirmPasswordController;
+  late final TextEditingController _fullNameController;
+  late final TextEditingController _emailController;
+  late final TextEditingController _passwordController;
+  late final TextEditingController _confirmPasswordController;
 
-  // Getters with null safety
-  TextEditingController get fullNameController {
-    _fullNameController ??= TextEditingController();
-    return _fullNameController!;
-  }
+  // Getters
+  TextEditingController get fullNameController => _fullNameController;
 
-  TextEditingController get emailController {
-    _emailController ??= TextEditingController();
-    return _emailController!;
-  }
+  TextEditingController get emailController => _emailController;
 
-  TextEditingController get passwordController {
-    _passwordController ??= TextEditingController();
-    return _passwordController!;
-  }
+  TextEditingController get passwordController => _passwordController;
 
-  TextEditingController get confirmPasswordController {
-    _confirmPasswordController ??= TextEditingController();
-    return _confirmPasswordController!;
-  }
+  TextEditingController get confirmPasswordController =>
+      _confirmPasswordController;
 
   // Form key
   late GlobalKey<FormState> formKey;
@@ -67,10 +56,10 @@ class SignUpController extends GetxController {
 
   @override
   void onClose() {
-    _fullNameController?.dispose();
-    _emailController?.dispose();
-    _passwordController?.dispose();
-    _confirmPasswordController?.dispose();
+    _fullNameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
     super.onClose();
   }
 

--- a/lib/features/auth/sub_features/sign_up/view/components/sign_up_action_button.dart
+++ b/lib/features/auth/sub_features/sign_up/view/components/sign_up_action_button.dart
@@ -11,7 +11,8 @@ class SignUpActionButton extends GetView<SignUpController> {
   Widget build(BuildContext context) {
     return Obx(() => CustomButton(
           text: 'Create Account',
-          onPressed: controller.isLoading ? null : controller.signUp,
+          onPressed:
+              controller.isLoading || !controller.acceptTerms ? null : controller.signUp,
           isLoading: controller.isLoading,
           backgroundColor: AppColors.primary,
         ));

--- a/lib/features/auth/sub_features/sign_up/view/components/sign_up_terms_conditions.dart
+++ b/lib/features/auth/sub_features/sign_up/view/components/sign_up_terms_conditions.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:budgetin/features/auth/sub_features/sign_up/controllers/sign_up_controller.dart';
+import 'package:budgetin/shared/styles/styles.dart';
+
+class SignUpTermsConditions extends GetView<SignUpController> {
+  const SignUpTermsConditions({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(
+      () => Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Checkbox(
+            value: controller.acceptTerms,
+            onChanged: controller.toggleAcceptTerms,
+            activeColor: AppColors.primary,
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                'I agree to the Terms & Conditions and Privacy Policy.',
+                style: AppFonts.primaryRegular14.copyWith(
+                  color: AppColors.text1_600,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/auth/sub_features/sign_up/view/ui/sign_up_screen.dart
+++ b/lib/features/auth/sub_features/sign_up/view/ui/sign_up_screen.dart
@@ -36,6 +36,11 @@ class SignUpScreen extends GetView<SignUpController> {
 
               SizedBox(height: 30.h),
 
+              // Terms & Conditions
+              const SignUpTermsConditions(),
+
+              SizedBox(height: 24.h),
+
               // Sign Up Button
               const SignUpActionButton(),
 

--- a/lib/utils/services/hive_service.dart
+++ b/lib/utils/services/hive_service.dart
@@ -48,6 +48,9 @@ class HiveService extends GetxService {
   /// Function for get data from the general box.
   T? get<T>({required String key}) => generalBox.get(key) as T?;
 
+  /// Remove data from the general box.
+  void remove({required String key}) => generalBox.delete(key);
+
   /* Function save bearer token to local */
   static String? getBearer() => authBox.get(HiveConstant.bearerToken);
   static Future<void> setBearer(String token) async => await authBox.put(

--- a/lib/utils/services/supabase_service.dart
+++ b/lib/utils/services/supabase_service.dart
@@ -130,13 +130,17 @@ class SupabaseService extends GetxService {
         redirectTo: null, // Biarkan Supabase handle redirect
       );
 
-      log('OAuth response: $response', name: 'SupabaseService');
       AppLogger.logSupabaseResponse(
         operation: 'signInWithGoogle',
         success: true,
-        data: {'method': 'OAuth', 'response': response},
+        data: {
+          'method': 'OAuth',
+          'userId': response.user?.id,
+          'hasSession': response.session != null,
+        },
       );
-      return response;
+
+      return true;
     } catch (e) {
       log('OAuth Sign In Error: $e', name: 'SupabaseService');
       AppLogger.logError('OAuth Sign In failed, trying fallback', error: e);
@@ -191,16 +195,19 @@ class SupabaseService extends GetxService {
 
         log('Native Google Sign In success: ${response.user?.email}',
             name: 'SupabaseService');
+        final hasUser = response.user != null;
+        final hasSession = response.session != null;
         AppLogger.logSupabaseResponse(
           operation: 'signInWithGoogle',
-          success: true,
+          success: hasUser || hasSession,
           data: {
             'method': 'native',
             'userId': response.user?.id,
             'email': response.user?.email,
+            'hasSession': hasSession,
           },
         );
-        return response.user != null;
+        return hasUser || hasSession;
       } catch (e2) {
         log('Native Google Sign In fallback error: $e2',
             name: 'SupabaseService');


### PR DESCRIPTION
## Summary
- manage the Supabase auth state listener lifecycle and surface Google sign-in failures consistently in `AuthController`
- persist the sign-in "remember me" preference and email in Hive while disposing text controllers correctly
- require accepting terms & conditions on sign-up with a dedicated widget and disable the submit button until satisfied
- ensure Supabase Google OAuth returns a boolean result and improve native fallback logging

## Testing
- `flutter analyze` *(fails: flutter tooling is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f8237e588327b2029f5f8f8fd9c7